### PR TITLE
adding initial cace-support

### DIFF
--- a/cace/scripts/run_lvs.tcl
+++ b/cace/scripts/run_lvs.tcl
@@ -1,0 +1,20 @@
+# Tcl script to run LVS
+
+if {[catch {set PDK_ROOT $::env(PDK_ROOT)}]} {set PDK_ROOT /usr/local/share/pdk}
+if {[catch {set PDK $::env(PDK)}]} {set PDK sky130A}
+
+set pdklib ${PDK_ROOT}/${PDK}
+set techlibs ${pdklib}/libs.tech
+set reflibs ${pdklib}/libs.ref
+set CACE_ROOT $::env(CACE_ROOT)
+
+set setupfile ${techlibs}/netgen/sky130A_setup.tcl
+set hvlib ${reflibs}/sky130_fd_sc_hvl/spice/sky130_fd_sc_hvl.spice
+
+set circuit1 [readnet spice $CACE_ROOT/netlist/layout/sky130_cw_ip__bandgap.spice]
+set circuit2 [readnet spice $hvlib]
+readnet spice $CACE_ROOT/netlist/schematic/sky130_cw_ip__bandgap.spice $circuit2
+
+lvs "$circuit1 sky130_cw_ip__bandgap" "$circuit2 sky130_cw_ip__bandgap" \
+        $setupfile sky130_cw_ip__bandgap_comp.out -json
+                                                    

--- a/cace/sky130_cw_ip.yaml
+++ b/cace/sky130_cw_ip.yaml
@@ -1,0 +1,79 @@
+#--------------------------------------------------------------
+# CACE circuit characterization file
+#--------------------------------------------------------------
+
+name: sky130_cw_ip__bandgap
+description: na
+PDK: sky130A
+
+cace_format: 5.2
+
+authorship:
+  designer: na
+  company: na
+  creation_date: na
+  license: Apache 2.0
+
+paths:
+  root: ..
+  documentation: docs
+  schematic: xschem
+  magic: mag
+  layout: gds
+  netlist: netlist
+
+parameters:
+  magic_area:
+    spec:
+      area:
+        display: Area
+        description: Total circuit layout area
+        unit: µm²
+        maximum:
+          value: any
+      width:
+        display: Width
+        description: Total circuit layout width
+        unit: µm
+        maximum:
+          value: any
+      height:
+        display: Height
+        description: Total circuit layout height
+        unit: µm
+        maximum:
+          value: any
+    tool:
+      magic_area
+
+  magic_drc:
+    description: Magic DRC
+    display: Magic DRC
+    spec:
+      drc_errors:
+        maximum:
+          value: 0
+    tool:
+      magic_drc
+
+  netgen_lvs:
+    description: Netgen LVS
+    display: Netgen LVS
+    spec:
+      lvs_errors:
+        maximum:
+          value: 0
+    tool:
+      netgen_lvs:
+        script: run_lvs.tcl
+
+  klayout_drc_full:
+    description: KLayout DRC full
+    display: KLayout DRC full
+    spec:
+      drc_errors:
+        maximum:
+          value: 0
+    tool:
+        klayout_drc:
+            args: ['-rd', 'feol=true', '-rd', 'beol=true', '-rd', 'offgrid=true']

--- a/cace/templates/xschemrc
+++ b/cace/templates/xschemrc
@@ -1,0 +1,2 @@
+# Source project xschemrc
+source [file dirname [info script]]/../../xschem/xschemrc


### PR DESCRIPTION
added an initial .yaml file for  "sky130_cw_ip__bandgap" supporting physical checks as a start. 
added a LVS tcl script. 
The bandgap passes physical checks through CACE except for LVS where circuits uniquely match but property errors found. 