### PR TITLE
LVS ci2409: Changes to schematics to pass LVS

### DIFF
--- a/xschem/bandgap/bandgap.sch
+++ b/xschem/bandgap/bandgap.sch
@@ -9,10 +9,10 @@ P 4 5 1070 -860 1070 20 1640 20 1640 -860 1070 -860 {}
 P 4 5 1000 -860 60 -860 60 20 1000 20 1000 -860 {}
 T {Startup} 1080 -850 0 0 0.4 0.4 {}
 T {Bandgap} 70 -850 0 0 0.4 0.4 {}
-N 390 -110 410 -110 {lab=#net1}
+N 390 -110 410 -110 {lab=vss}
 N 390 0 450 0 {lab=vss}
 N 450 0 510 0 {lab=vss}
-N 100 -110 120 -110 {lab=#net3}
+N 100 -110 120 -110 {lab=vss}
 N 100 0 160 0 {lab=vss}
 N 160 0 220 0 {lab=vss}
 N 450 -800 450 -740 {lab=vdd}
@@ -45,9 +45,9 @@ N 730 -530 730 -490 { lab=vdd}
 N 450 -500 450 -480 { lab=vp}
 N 450 -480 450 -390 { lab=vp}
 N 400 -200 400 -170 { lab=vss}
-N 450 -330 450 -280 { lab=#net5}
+N 450 -330 450 -280 { lab=#net1}
 N 360 -240 380 -240 { lab=trim[15:0]}
-N 450 -200 450 -140 { lab=#net6}
+N 450 -200 450 -140 { lab=#net2}
 N 710 -400 710 -370 { lab=bias}
 N 830 -450 910 -450 { lab=gate}
 N 880 -450 880 -380 { lab=gate}
@@ -78,15 +78,21 @@ N 1350 -340 1390 -340 { lab=vdd}
 N 1430 -340 1450 -340 { lab=vs2}
 N 1450 -390 1450 -340 { lab=vs2}
 N 1430 -390 1450 -390 { lab=vs2}
-N 100 -110 100 0 {}
-N 160 -80 160 0 {}
-N 390 -110 390 0 {}
-N 450 -80 450 0 {}
+N 100 -110 100 0 {
+lab=vss}
+N 160 -80 160 0 {
+lab=vss}
+N 390 -110 390 0 {
+lab=vss}
+N 450 -80 450 0 {
+lab=vss}
 C {sky130_fd_pr/pnp_05v5.sym} 430 -110 0 0 {name=Q2
-model="pnp_05v5_W0p68L0p68 m=8"
+model="pnp_05v5_W0p68L0p68"
+m=8
 spiceprefix=X}
 C {sky130_fd_pr/pnp_05v5.sym} 140 -110 0 0 {name=Q1
-model="pnp_05v5_W0p68L0p68 m=1"
+model="pnp_05v5_W0p68L0p68"
+m=1
 spiceprefix=X}
 C {devices/lab_wire.sym} 320 0 0 0 {name=l2 sig_type=std_logic lab=vss}
 C {devices/lab_wire.sym} 660 -480 0 0 {name=l22 sig_type=std_logic lab=vp}
@@ -103,9 +109,8 @@ C {sky130_fd_pr/cap_mim_m3_1.sym} 880 -350 0 0 {name=C1 model=cap_mim_m3_1 W=10 
 C {bandgap/bg_res.sym} 280 -470 0 0 {name=xres
 }
 C {devices/lab_wire.sym} 310 -500 3 0 {name=l4 sig_type=std_logic lab=vss}
-C {sky130_fd_pr/res_xhigh_po.sym} 450 -360 0 0 {name=R1
+C {sky130_fd_pr/res_xhigh_po_0p69.sym} 450 -360 0 0 {name=R1
 L=13
-model=res_xhigh_po_0p69
 spiceprefix=X
 mult=1
 }

--- a/xschem/bandgap/bg_res.sch
+++ b/xschem/bandgap/bg_res.sch
@@ -44,9 +44,9 @@ N 590 -120 590 -100 {lab=#net15}
 N 390 -120 390 -100 {lab=#net16}
 N 590 -40 590 -20 {lab=#net17}
 N 390 -40 390 -20 {lab=#net18}
-C {sky130_fd_pr/res_xhigh_po.sym} 390 -710 0 0 {name=R1
+C {sky130_fd_pr/res_xhigh_po_0p69.sym} 390 -710 0 0 {name=R1
 L=13
-model=res_xhigh_po_0p69
+
 spiceprefix=X
 mult=1}
 C {devices/lab_wire.sym} 370 -710 0 0 {name=l1 sig_type=std_logic lab=vss}
@@ -74,98 +74,98 @@ C {devices/lab_wire.sym} 370 -70 0 0 {name=l17 sig_type=std_logic lab=vss}
 C {devices/lab_wire.sym} 570 -70 0 0 {name=l18 sig_type=std_logic lab=vss}
 C {devices/lab_wire.sym} 370 10 0 0 {name=l19 sig_type=std_logic lab=vss}
 C {devices/lab_wire.sym} 570 10 0 0 {name=l20 sig_type=std_logic lab=vss}
-C {sky130_fd_pr/res_xhigh_po.sym} 590 -710 0 0 {name=R2
+C {sky130_fd_pr/res_xhigh_po_0p69.sym} 590 -710 0 0 {name=R2
 L=13
-model=res_xhigh_po_0p69
+
 spiceprefix=X
 mult=1}
-C {sky130_fd_pr/res_xhigh_po.sym} 390 -630 0 0 {name=R3
+C {sky130_fd_pr/res_xhigh_po_0p69.sym} 390 -630 0 0 {name=R3
 L=13
-model=res_xhigh_po_0p69
+
 spiceprefix=X
 mult=1}
-C {sky130_fd_pr/res_xhigh_po.sym} 590 -630 0 0 {name=R4
+C {sky130_fd_pr/res_xhigh_po_0p69.sym} 590 -630 0 0 {name=R4
 L=13
-model=res_xhigh_po_0p69
+
 spiceprefix=X
 mult=1}
-C {sky130_fd_pr/res_xhigh_po.sym} 390 -550 0 0 {name=R5
+C {sky130_fd_pr/res_xhigh_po_0p69.sym} 390 -550 0 0 {name=R5
 L=13
-model=res_xhigh_po_0p69
+
 spiceprefix=X
 mult=1}
-C {sky130_fd_pr/res_xhigh_po.sym} 590 -550 0 0 {name=R6
+C {sky130_fd_pr/res_xhigh_po_0p69.sym} 590 -550 0 0 {name=R6
 L=13
-model=res_xhigh_po_0p69
+
 spiceprefix=X
 mult=1}
-C {sky130_fd_pr/res_xhigh_po.sym} 390 -470 0 0 {name=R7
+C {sky130_fd_pr/res_xhigh_po_0p69.sym} 390 -470 0 0 {name=R7
 L=13
-model=res_xhigh_po_0p69
+
 spiceprefix=X
 mult=1}
-C {sky130_fd_pr/res_xhigh_po.sym} 590 -470 0 0 {name=R8
+C {sky130_fd_pr/res_xhigh_po_0p69.sym} 590 -470 0 0 {name=R8
 L=13
-model=res_xhigh_po_0p69
+
 spiceprefix=X
 mult=1}
-C {sky130_fd_pr/res_xhigh_po.sym} 390 -390 0 0 {name=R9
+C {sky130_fd_pr/res_xhigh_po_0p69.sym} 390 -390 0 0 {name=R9
 L=13
-model=res_xhigh_po_0p69
+
 spiceprefix=X
 mult=1}
-C {sky130_fd_pr/res_xhigh_po.sym} 590 -390 0 0 {name=R10
+C {sky130_fd_pr/res_xhigh_po_0p69.sym} 590 -390 0 0 {name=R10
 L=13
-model=res_xhigh_po_0p69
+
 spiceprefix=X
 mult=1}
-C {sky130_fd_pr/res_xhigh_po.sym} 390 -310 0 0 {name=R11
+C {sky130_fd_pr/res_xhigh_po_0p69.sym} 390 -310 0 0 {name=R11
 L=13
-model=res_xhigh_po_0p69
+
 spiceprefix=X
 mult=1}
-C {sky130_fd_pr/res_xhigh_po.sym} 590 -310 0 0 {name=R12
+C {sky130_fd_pr/res_xhigh_po_0p69.sym} 590 -310 0 0 {name=R12
 L=13
-model=res_xhigh_po_0p69
+
 spiceprefix=X
 mult=1}
-C {sky130_fd_pr/res_xhigh_po.sym} 390 -230 0 0 {name=R13
+C {sky130_fd_pr/res_xhigh_po_0p69.sym} 390 -230 0 0 {name=R13
 L=13
-model=res_xhigh_po_0p69
+
 spiceprefix=X
 mult=1}
-C {sky130_fd_pr/res_xhigh_po.sym} 590 -230 0 0 {name=R14
+C {sky130_fd_pr/res_xhigh_po_0p69.sym} 590 -230 0 0 {name=R14
 L=13
-model=res_xhigh_po_0p69
+
 spiceprefix=X
 mult=1}
-C {sky130_fd_pr/res_xhigh_po.sym} 390 -150 0 0 {name=R15
+C {sky130_fd_pr/res_xhigh_po_0p69.sym} 390 -150 0 0 {name=R15
 L=13
-model=res_xhigh_po_0p69
+
 spiceprefix=X
 mult=1}
-C {sky130_fd_pr/res_xhigh_po.sym} 590 -150 0 0 {name=R16
+C {sky130_fd_pr/res_xhigh_po_0p69.sym} 590 -150 0 0 {name=R16
 L=13
-model=res_xhigh_po_0p69
+
 spiceprefix=X
 mult=1}
-C {sky130_fd_pr/res_xhigh_po.sym} 390 -70 0 0 {name=R17
+C {sky130_fd_pr/res_xhigh_po_0p69.sym} 390 -70 0 0 {name=R17
 L=13
-model=res_xhigh_po_0p69
+
 spiceprefix=X
 mult=1}
-C {sky130_fd_pr/res_xhigh_po.sym} 590 -70 0 0 {name=R18
+C {sky130_fd_pr/res_xhigh_po_0p69.sym} 590 -70 0 0 {name=R18
 L=13
-model=res_xhigh_po_0p69
+
 spiceprefix=X
 mult=1}
-C {sky130_fd_pr/res_xhigh_po.sym} 390 10 0 0 {name=R19
+C {sky130_fd_pr/res_xhigh_po_0p69.sym} 390 10 0 0 {name=R19
 L=13
-model=res_xhigh_po_0p69
+
 spiceprefix=X
 mult=1}
-C {sky130_fd_pr/res_xhigh_po.sym} 590 10 0 0 {name=R20
+C {sky130_fd_pr/res_xhigh_po_0p69.sym} 590 10 0 0 {name=R20
 L=13
-model=res_xhigh_po_0p69
+
 spiceprefix=X
 mult=1}

--- a/xschem/bandgap/bg_trim.sch
+++ b/xschem/bandgap/bg_trim.sch
@@ -478,98 +478,98 @@ C {devices/lab_wire.sym} 130 -200 0 0 {name=l45 sig_type=std_logic lab=bot
 C {devices/lab_wire.sym} 130 -70 0 0 {name=l47 sig_type=std_logic lab=bot
 }
 C {sky130_fd_pr/res_high_po_1p41.sym} 270 -1930 0 0 {name=R15
-L=2.8
-model=res_high_po_1p41
+L=2.92
+
 spiceprefix=X
 mult=1
 }
 C {sky130_fd_pr/res_high_po_1p41.sym} 270 -250 0 0 {name=R1
-L=2.8
-model=res_high_po_1p41
+L=2.92
+
 spiceprefix=X
 mult=1
 }
 C {sky130_fd_pr/res_high_po_1p41.sym} 270 -130 0 0 {name=R16
-L=2.8
-model=res_high_po_1p41
+L=2.92
+
 spiceprefix=X
 mult=1
 }
 C {sky130_fd_pr/res_high_po_1p41.sym} 270 -370 0 0 {name=R2
-L=2.8
-model=res_high_po_1p41
+L=2.92
+
 spiceprefix=X
 mult=1
 }
 C {sky130_fd_pr/res_high_po_1p41.sym} 270 -490 0 0 {name=R3
-L=2.8
-model=res_high_po_1p41
+L=2.92
+
 spiceprefix=X
 mult=1
 }
 C {sky130_fd_pr/res_high_po_1p41.sym} 270 -610 0 0 {name=R4
-L=2.8
-model=res_high_po_1p41
+L=2.92
+
 spiceprefix=X
 mult=1
 }
 C {sky130_fd_pr/res_high_po_1p41.sym} 270 -730 0 0 {name=R5
-L=2.8
-model=res_high_po_1p41
+L=2.92
+
 spiceprefix=X
 mult=1
 }
 C {sky130_fd_pr/res_high_po_1p41.sym} 270 -850 0 0 {name=R6
-L=2.8
-model=res_high_po_1p41
+L=2.92
+
 spiceprefix=X
 mult=1
 }
 C {sky130_fd_pr/res_high_po_1p41.sym} 270 -970 0 0 {name=R7
-L=2.8
-model=res_high_po_1p41
+L=2.92
+
 spiceprefix=X
 mult=1
 }
 C {sky130_fd_pr/res_high_po_1p41.sym} 270 -1090 0 0 {name=R8
-L=2.8
-model=res_high_po_1p41
+L=2.92
+
 spiceprefix=X
 mult=1
 }
 C {sky130_fd_pr/res_high_po_1p41.sym} 270 -1210 0 0 {name=R9
-L=2.8
-model=res_high_po_1p41
+L=2.92
+
 spiceprefix=X
 mult=1
 }
 C {sky130_fd_pr/res_high_po_1p41.sym} 270 -1330 0 0 {name=R10
-L=2.8
-model=res_high_po_1p41
+L=2.92
+
 spiceprefix=X
 mult=1
 }
 C {sky130_fd_pr/res_high_po_1p41.sym} 270 -1450 0 0 {name=R11
-L=2.8
-model=res_high_po_1p41
+L=2.92
+
 spiceprefix=X
 mult=1
 }
 C {sky130_fd_pr/res_high_po_1p41.sym} 270 -1570 0 0 {name=R12
-L=2.8
-model=res_high_po_1p41
+L=2.92
+
 spiceprefix=X
 mult=1
 }
 C {sky130_fd_pr/res_high_po_1p41.sym} 270 -1690 0 0 {name=R13
-L=2.8
-model=res_high_po_1p41
+L=2.92
+
 spiceprefix=X
 mult=1
 }
 C {sky130_fd_pr/res_high_po_1p41.sym} 270 -1810 0 0 {name=R14
-L=2.8
-model=res_high_po_1p41
+L=2.92
+
 spiceprefix=X
 mult=1
 }

--- a/xschem/bias/bias_basis_current.sch
+++ b/xschem/bias/bias_basis_current.sch
@@ -236,15 +236,13 @@ nrd="'0.29 / W'" nrs="'0.29 / W'"
 sa=0 sb=0 sd=0
 model=pfet_01v8_lvt
 spiceprefix=X}
-C {sky130_fd_pr/res_xhigh_po.sym} 920 -130 0 0 {name=R2
-L=14
-model=res_xhigh_po_0p35
+C {sky130_fd_pr/res_xhigh_po_0p35.sym} 920 -130 0 0 {name=R2
+L=14.24
 spiceprefix=X
 mult=1
 }
-C {sky130_fd_pr/res_xhigh_po.sym} 210 -430 0 0 {name=R1
-L=17
-model=res_xhigh_po_0p35
+C {sky130_fd_pr/res_xhigh_po_0p35.sym} 210 -430 0 0 {name=R1
+L=17.24
 spiceprefix=X
 mult=1
 }

--- a/xschem/opamp/se_folded_cascode_p.sch
+++ b/xschem/opamp/se_folded_cascode_p.sch
@@ -1,4 +1,5 @@
-v {xschem version=3.0.0 file_version=1.2 }
+v {xschem version=3.4.5 file_version=1.2
+}
 G {}
 K {}
 V {}
@@ -150,6 +151,17 @@ N 2160 -50 2240 -50 { lab=diff}
 N 2160 -120 2160 -50 { lab=diff}
 N 2160 -200 2240 -200 { lab=diff}
 N 2240 -120 2270 -120 { lab=vdd}
+N 1910 -610 1910 -530 { lab=vdd}
+N 1910 -530 1950 -530 { lab=vdd}
+N 1990 -610 1990 -560 { lab=vdd}
+N 1990 -500 1990 -460 { lab=vdd}
+N 1910 -460 1990 -460 { lab=vdd}
+N 1910 -530 1910 -460 { lab=vdd}
+N 1910 -610 1990 -610 { lab=vdd}
+N 1990 -610 2070 -610 { lab=vdd}
+N 1990 -460 2070 -460 { lab=vdd}
+N 2070 -610 2070 -460 { lab=vdd}
+N 1990 -530 2070 -530 { lab=vdd}
 C {sky130_fd_pr/pfet_01v8_lvt.sym} 970 -450 0 1 {name=M3
 L=1
 W=4
@@ -414,7 +426,7 @@ C {devices/lab_wire.sym} 1200 -580 0 1 {name=l6 sig_type=std_logic lab=nd10
 }
 C {devices/lab_wire.sym} 1460 -580 0 1 {name=l7 sig_type=std_logic lab=nd11
 }
-C {sky130_fd_pr/pfet_01v8_lvt.sym} 1970 -750 0 0 {name=MDUM1[41:0]
+C {sky130_fd_pr/pfet_01v8_lvt.sym} 1970 -750 0 0 {name=MDUM1[43:0]
 L=4
 W=2
 nf=1
@@ -527,3 +539,18 @@ C {devices/lab_wire.sym} 2160 -200 0 1 {name=l50 sig_type=std_logic lab=diff
 }
 C {devices/lab_wire.sym} 1910 -400 0 1 {name=l19 sig_type=std_logic lab=vss}
 C {devices/lab_wire.sym} 2240 -320 0 1 {name=l20 sig_type=std_logic lab=vss}
+C {sky130_fd_pr/pfet_01v8_lvt.sym} 1970 -530 0 0 {name=MDUM8[31:0]
+L=1
+W=1
+nf=1
+mult=1
+ad="'int((nf+1)/2) * W/nf * 0.29'" 
+pd="'2*int((nf+1)/2) * (W/nf + 0.29)'"
+as="'int((nf+2)/2) * W/nf * 0.29'" 
+ps="'2*int((nf+2)/2) * (W/nf + 0.29)'"
+nrd="'0.29 / W'" nrs="'0.29 / W'"
+sa=0 sb=0 sd=0
+model=pfet_01v8_lvt
+spiceprefix=X
+}
+C {devices/lab_wire.sym} 1910 -610 0 1 {name=l15 sig_type=std_logic lab=vdd}

--- a/xschem/sky130_cw_ip__bandgap.sym
+++ b/xschem/sky130_cw_ip__bandgap.sym
@@ -1,31 +1,26 @@
-v {xschem version=3.4.5 file_version=1.2
-}
-G {}
-K {type=primitive
+v {xschem version=3.4.5 file_version=1.2}
+K {type=subcircuit
 format="@name @pinlist @symname"
 template="name=x1"
 }
-V {}
-S {}
-E {}
+T {@symname} -112.5 -6 0 0 0.3 0.3 {}
+T {@name} 135 -52 0 0 0.2 0.2 {}
 L 4 -130 -40 130 -40 {}
 L 4 -130 40 130 40 {}
 L 4 -130 -40 -130 40 {}
 L 4 130 -40 130 40 {}
-L 4 -150 -30 -130 -30 {}
-L 4 130 -10 150 -10 {}
-L 7 130 -30 150 -30 {}
-L 7 130 10 150 10 {}
-L 7 130 30 150 30 {}
 B 5 147.5 -32.5 152.5 -27.5 {name=vdd dir=inout}
-B 5 -152.5 -32.5 -147.5 -27.5 {name=trim[15:0] dir=in}
-B 5 147.5 -12.5 152.5 -7.5 {name=vbg dir=out}
-B 5 147.5 7.5 152.5 12.5 {name=vss dir=inout}
-B 5 147.5 27.5 152.5 32.5 {name=vsub dir=inout}
-T {@symname} -112.5 -6 0 0 0.3 0.3 {}
-T {@name} 135 -52 0 0 0.2 0.2 {}
+L 7 130 -30 150 -30 {}
 T {vdd} 125 -34 0 1 0.2 0.2 {}
+B 5 -152.5 -32.5 -147.5 -27.5 {name=trim[15:0] dir=in}
+L 4 -150 -30 -130 -30 {}
 T {trim[15:0]} -125 -34 0 0 0.2 0.2 {}
+B 5 147.5 -12.5 152.5 -7.5 {name=vbg dir=out}
+L 4 130 -10 150 -10 {}
 T {vbg} 125 -14 0 1 0.2 0.2 {}
+B 5 147.5 7.5 152.5 12.5 {name=vss dir=inout}
+L 7 130 10 150 10 {}
 T {vss} 125 6 0 1 0.2 0.2 {}
+B 5 147.5 27.5 152.5 32.5 {name=vsub dir=inout}
+L 7 130 30 150 30 {}
 T {vsub} 125 26 0 1 0.2 0.2 {}

--- a/xschem/sky130_cw_ip__bandgap.sym
+++ b/xschem/sky130_cw_ip__bandgap.sym
@@ -1,26 +1,31 @@
-v {xschem version=3.4.5 file_version=1.2}
-K {type=subcircuit
+v {xschem version=3.4.5 file_version=1.2
+}
+G {}
+K {type=primitive
 format="@name @pinlist @symname"
 template="name=x1"
 }
-T {@symname} -112.5 -6 0 0 0.3 0.3 {}
-T {@name} 135 -52 0 0 0.2 0.2 {}
+V {}
+S {}
+E {}
 L 4 -130 -40 130 -40 {}
 L 4 -130 40 130 40 {}
 L 4 -130 -40 -130 40 {}
 L 4 130 -40 130 40 {}
-B 5 147.5 -32.5 152.5 -27.5 {name=vdd dir=inout}
-L 7 130 -30 150 -30 {}
-T {vdd} 125 -34 0 1 0.2 0.2 {}
-B 5 -152.5 -32.5 -147.5 -27.5 {name=trim[15:0] dir=in}
 L 4 -150 -30 -130 -30 {}
-T {trim[15:0]} -125 -34 0 0 0.2 0.2 {}
-B 5 147.5 -12.5 152.5 -7.5 {name=vbg dir=out}
 L 4 130 -10 150 -10 {}
-T {vbg} 125 -14 0 1 0.2 0.2 {}
-B 5 147.5 7.5 152.5 12.5 {name=vss dir=inout}
+L 7 130 -30 150 -30 {}
 L 7 130 10 150 10 {}
-T {vss} 125 6 0 1 0.2 0.2 {}
-B 5 147.5 27.5 152.5 32.5 {name=vsub dir=inout}
 L 7 130 30 150 30 {}
+B 5 147.5 -32.5 152.5 -27.5 {name=vdd dir=inout}
+B 5 -152.5 -32.5 -147.5 -27.5 {name=trim[15:0] dir=in}
+B 5 147.5 -12.5 152.5 -7.5 {name=vbg dir=out}
+B 5 147.5 7.5 152.5 12.5 {name=vss dir=inout}
+B 5 147.5 27.5 152.5 32.5 {name=vsub dir=inout}
+T {@symname} -112.5 -6 0 0 0.3 0.3 {}
+T {@name} 135 -52 0 0 0.2 0.2 {}
+T {vdd} 125 -34 0 1 0.2 0.2 {}
+T {trim[15:0]} -125 -34 0 0 0.2 0.2 {}
+T {vbg} 125 -14 0 1 0.2 0.2 {}
+T {vss} 125 6 0 1 0.2 0.2 {}
 T {vsub} 125 26 0 1 0.2 0.2 {}


### PR DESCRIPTION
Corrected model names, device sizes, and dummy device counts and connectivity.

The differences in the net related lines appear related to xschem version. When the base file was saved with a later version, there were no net related differences.